### PR TITLE
Add legacyBehavior parameter to Link components

### DIFF
--- a/components/Heading.tsx
+++ b/components/Heading.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 
 export function Heading({ id = "", level = 1, children, className }) {
   return (
-    <Link href={`#${id}`}>
+    <Link legacyBehavior href={`#${id}`}>
       <a className="no-color">
         {React.createElement(
           `h${level}`,

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -12,7 +12,7 @@ export function Link({ href, children }) {
     )
   } else {
     return (
-      <NextLink href={href}>
+      <NextLink legacyBehavior href={href}>
         <a>{children}</a>
       </NextLink>
     )

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -44,7 +44,7 @@ export function TableOfContents({ toc }) {
           >
             <ul className="pl-4 lg:pl-0">
               <li className="text-theme text-2xl lg:text-xl font-bold">
-                <Link href="#root" passHref>
+                <Link legacyBehavior href="#root" passHref>
                   <a>目次</a>
                 </Link>
               </li>
@@ -63,7 +63,7 @@ export function TableOfContents({ toc }) {
                       .filter(Boolean)
                       .join(" ")}
                   >
-                    <Link href={href} passHref>
+                    <Link legacyBehavior href={href} passHref>
                       <a
                         onClick={() => {
                           setOpen(false)

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -9,7 +9,7 @@ export function TopNav() {
         "bg-theme text-white shadow-[0_2px_4px_2px_rgb(0_0_0_/_0.1)]"
       }
     >
-      <Link href="/">
+      <Link legacyBehavior href="/">
         <a className="text-xl font-bold">名前のない日記。</a>
       </Link>
       <div className="ml-auto opacity-50 hover:opacity-100">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -54,7 +54,7 @@ const Index = (props) => (
       <h1>記事一覧</h1>
     </div>
     {props.articles.map((article) => (
-      <Link href={`/articles/${article.name}`} key={article.name}>
+      <Link legacyBehavior href={`/articles/${article.name}`} key={article.name}>
         <a>
           <div className="content-bg round p-4 w-full rounded">
             <h2>{article.title}</h2>


### PR DESCRIPTION
Without the legacyBehavior parameter, <a> tags cannot be children of the Link Markdoc component.